### PR TITLE
Update softmax_regression_impl.hpp

### DIFF
--- a/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
+++ b/src/mlpack/methods/softmax_regression/softmax_regression_impl.hpp
@@ -46,7 +46,8 @@ SoftmaxRegression<OptimizerType>::SoftmaxRegression(
     parameters(optimizer.Function().GetInitialPoint()),
     inputSize(optimizer.Function().InputSize()),
     numClasses(optimizer.Function().NumClasses()),
-    lambda(optimizer.Function().Lambda())
+    lambda(optimizer.Function().Lambda()),
+    fitIntercept(optimizer.Function().FitIntercept())
 {
   // Train the model.
   Timer::Start("softmax_regression_optimization");


### PR DESCRIPTION
When I used a SoftmaxRegressionFunction OptimizerType object to initialize a SoftmaxRegression object, there must forget to initialize member variable fitIntercept.
